### PR TITLE
Fix CVE ID path trimming

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 export default {
   async fetch(request, env, ctx) {
     const url = new URL(request.url);
-    const cveId = url.pathname.replace("/", "").toUpperCase();
+    const cveId = url.pathname.replace(/^\/+|\/+$/g, "").toUpperCase();
 
     if (!/^CVE-\d{4}-\d+$/.test(cveId)) {
       return new Response("Invalid CVE format", { status: 400 });

--- a/test/extract.test.js
+++ b/test/extract.test.js
@@ -1,0 +1,11 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+function extractCVEId(pathname) {
+  return pathname.replace(/^\/+|\/+$/g, '').toUpperCase();
+}
+
+test('trailing slash trimmed', () => {
+  const cveId = extractCVEId('/CVE-2024-1234/');
+  assert.equal(cveId, 'CVE-2024-1234');
+});


### PR DESCRIPTION
## Summary
- handle extra slashes when parsing CVE IDs
- add regression test for trailing slash paths

## Testing
- `node --test test/extract.test.js`


------
https://chatgpt.com/codex/tasks/task_e_684c5824348c83299da8023036456cf7