### PR TITLE
Simplify test setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,15 @@
+# cve.tips
+
+## Running tests
+
+Install dependencies once:
+
+```bash
+npm install
+```
+
+Build the TypeScript sources and run the test suite using Node's built-in runner:
+
+```bash
+npm test
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,29 @@
+{
+  "name": "cve.tips",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cve.tips",
+      "version": "1.0.0",
+      "devDependencies": {
+        "typescript": "^5.8.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "cve.tips",
+  "version": "1.0.0",
+  "description": "",
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "test": "npm run build && node --test dist/tests/**/*.js"
+  },
+  "devDependencies": {
+    "typescript": "^5.8.3"
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -121,3 +121,4 @@ async function fetchEPSSBatch(cveIds) {
     return {};
   }
 }
+export { getNearbyCVEIds, fetchEPSSBatch };

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -1,0 +1,28 @@
+import { strict as assert } from 'node:assert';
+import { test } from 'node:test';
+import { getNearbyCVEIds, fetchEPSSBatch } from '../src/index.js';
+
+test('getNearbyCVEIds returns expected list when extra is 4', () => {
+  const result = getNearbyCVEIds('CVE-2024-0001', 4);
+  assert.deepEqual(result, [
+    'CVE-2024-0001',
+    'CVE-2024-0002',
+    'CVE-2024-0003',
+    'CVE-2024-0004',
+    'CVE-2024-0005'
+  ]);
+});
+
+test('fetchEPSSBatch returns empty object for empty array', async (t) => {
+  const fetchMock = t.mock.method(globalThis, 'fetch');
+  const result = await fetchEPSSBatch([]);
+  assert.deepEqual(result, {});
+  assert.equal(fetchMock.mock.callCount(), 0);
+});
+
+test('fetchEPSSBatch handles network errors gracefully', async (t) => {
+  const fetchMock = t.mock.method(globalThis, 'fetch', () => Promise.reject(new Error('network')));
+  const result = await fetchEPSSBatch(['CVE-2024-1234']);
+  assert.deepEqual(result, {});
+  assert.equal(fetchMock.mock.callCount(), 1);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ES2020",
+    "outDir": "dist",
+    "rootDir": ".",
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "strict": false,
+    "allowJs": true
+  },
+  "include": ["src/**/*", "tests/**/*"]
+}


### PR DESCRIPTION
## Summary
- switch to Node's built‑in test runner
- remove Jest and heavy dependencies
- compile sources with TypeScript before running tests
- document new `npm test` workflow

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684c63c940108329bebac2c18e6f8fed