### PR TITLE
Add CI test workflow before deployment

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -1,0 +1,33 @@
+name: Test and Deploy
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm test
+
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npx wrangler publish
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -13,3 +13,9 @@ Build the TypeScript sources and run the test suite using Node's built-in runner
 ```bash
 npm test
 ```
+
+## Continuous Integration
+
+A GitHub Actions workflow runs `npm test` on every push and pull request. When
+pushing to the `main` branch, the workflow will only deploy if the test job
+succeeds.


### PR DESCRIPTION
## Summary
- set up GitHub Actions workflow to run tests and deploy
- document CI in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ca3ed594083298ac048378bdd8f36