### PR TITLE
Add CI test workflow before deployment

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -1,0 +1,32 @@
+name: Test and Deploy
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm test
+
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npx wrangler publish
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -13,3 +13,11 @@ Build the TypeScript sources and run the test suite using Node's built-in runner
 ```bash
 npm test
 ```
+
+This compiles the TypeScript sources and runs Node's test runner over
+the compiled tests and any JavaScript tests.
+
+## Continuous Integration
+
+A GitHub Actions workflow runs `npm test` on every push and pull request.
+Deployment occurs from the `main` branch only after the test job succeeds.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc",
-    "test": "npm run build && node --test dist/tests/**/*.js"
+    "test": "npm run build && node --test \"dist/tests/**/*.js\" \"test/**/*.js\""
   },
   "devDependencies": {
     "typescript": "^5.8.3"


### PR DESCRIPTION
## Summary
- fix CI trigger to run tests on every push
- clarify testing instructions and test runner command
- quote glob patterns so Node finds compiled tests reliably

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684ca3ed594083298ac048378bdd8f36