### PR TITLE
fix: use wrangler deploy command

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -28,6 +28,6 @@ jobs:
           node-version: 20
           cache: 'npm'
       - run: npm ci
-      - run: npx wrangler publish
+      - run: npx wrangler deploy
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary
- replace deprecated `npx wrangler publish` with `npx wrangler deploy` in CI

## Testing
- `npm ci`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ade1105bd48329a16001c10ceae428