### PR TITLE
chore: add package.json description (pipeline smoke test)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cve.tips",
   "version": "1.0.0",
-  "description": "",
+  "description": "Cloudflare Worker that serves CVE details enriched with EPSS scores, backed by an R2 cache.",
   "type": "module",
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
## Summary

- Fills in the empty `description` field in `package.json` with a one-line summary of the project.

## Purpose

Behaviorally a no-op — used to validate the `test` + `deploy` GitHub Actions pipeline end-to-end after confirming the `CLOUDFLARE_API_TOKEN` secret is still valid. The deploy job only runs on pushes to `main`, so merging this PR will trigger the actual Cloudflare Worker deploy.

## Test plan

- [x] `test` job runs green on the PR (Node build + `node --test`).
- [ ] After merge to `main`, the `deploy` job runs and `npx wrangler deploy` succeeds.
- [ ] Hitting the live Worker (`/docs` or a known `/CVE-YYYY-N`) returns the expected response.