### PR TITLE
ci: switch to wrangler-action@v3 and bump Node to 22

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
       - run: npm ci
       - run: npm test
@@ -25,9 +25,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
       - run: npm ci
-      - run: npx wrangler deploy
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      - uses: cloudflare/wrangler-action@v3
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary\n\n- Replace `npx wrangler deploy` with `cloudflare/wrangler-action@v3` for better auth handling and version pinning.\n- Bump Node from 20 → 22, clearing the Actions deprecation warning.\n\n## Context\n\nThe Actions `deploy` job has been failing on every merge to `main` since at least Aug 2025 (exit code 1 in ~8s — auth error). Deploys have been reaching Cloudflare via the Workers Builds GitHub App integration, not via this workflow.\n\nThis PR fixes the Actions side. After merging, **you also need to rotate the `CLOUDFLARE_API_TOKEN` repo secret** — the current token is invalid.\n\n### Token rotation steps\n\n1. Go to https://dash.cloudflare.com/profile/api-tokens\n2. Create a new token with:\n   - Account → Cloudflare Workers Scripts → Edit\n   - Account → Cloudflare Workers R2 Storage → Edit\n   - Scoped to your account only\n3. Go to GitHub → repo Settings → Secrets and variables → Actions\n4. Update `CLOUDFLARE_API_TOKEN` with the new value\n\n## Test plan\n\n- [x] Workflow syntax is valid YAML\n- [ ] `test` job passes on this PR\n- [ ] After merge + token rotation, `deploy` job goes green on `main`\n- [ ] Workers Builds continues deploying in parallel (no changes to it)\n\nhttps://claude.ai/code/session_01BAxzT7PtzXB35rH94hncrS